### PR TITLE
feat: use cdk-made ec2 instance for osrm needs

### DIFF
--- a/infrastructure/komyut-cdk/.gitignore
+++ b/infrastructure/komyut-cdk/.gitignore
@@ -2,6 +2,7 @@
 !jest.config.js
 *.d.ts
 node_modules
+temp
 
 # CDK asset staging directory
 .cdk.staging

--- a/infrastructure/komyut-cdk/bin/komyut-cdk.ts
+++ b/infrastructure/komyut-cdk/bin/komyut-cdk.ts
@@ -15,6 +15,10 @@ new KomyutCdkStack(app, 'KomyutCdkStack', {
   /* Uncomment the next line if you know exactly what Account and Region you
    * want to deploy the stack to. */
   // env: { account: '123456789012', region: 'us-east-1' },
+  env: {
+    account: process.env.AWS_ACCOUNT_ID || process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.AWS_REGION || process.env.CDK_DEFAULT_REGION,
+  },
 
   /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
 });

--- a/infrastructure/komyut-cdk/calculation/routesolver.ts
+++ b/infrastructure/komyut-cdk/calculation/routesolver.ts
@@ -97,34 +97,34 @@ function findClosestRouteNodes(coord: [number, number], routePack: RoutePack, li
 }
 
 async function getOSRMWalkingDistance(from: [number, number], to: [number, number]) {
-    // const coordStr = [
-    //     [from[0], from[1]],
-    //     [to[0], to[1]]
-    // ].map(([lat, lng]) => `${lng},${lat}`).join(';');
-    // const url = `http://router.project-osrm.org/route/v1/bike/${coordStr}?overview=false`;
+    const coordStr = [
+        [from[0], from[1]],
+        [to[0], to[1]]
+    ].map(([lat, lng]) => `${lng},${lat}`).join(';');
+    const url = `http://${process.env.EC2_OSRM_PRIVATE_IP}:5000/route/v1/bike/${coordStr}?overview=false`;
 
-    // const res = await fetch(url);
-    // const json: any = await res.json();
+    const res = await fetch(url);
+    const json: any = await res.json();
 
-    // return json.routes[0].distance;
+    return json.routes[0].distance;
 
     //Replace with haversine temporarily
-    const toRadians = (deg: number) => deg * (Math.PI / 180);
-    const R = 6371e3; // Earth radius in meters
+    // const toRadians = (deg: number) => deg * (Math.PI / 180);
+    // const R = 6371e3; // Earth radius in meters
 
-    const φ1 = toRadians(from[0]);
-    const φ2 = toRadians(to[0]);
-    const Δφ = toRadians(to[0] - from[0]);
-    const Δλ = toRadians(to[1] - from[1]);
+    // const φ1 = toRadians(from[0]);
+    // const φ2 = toRadians(to[0]);
+    // const Δφ = toRadians(to[0] - from[0]);
+    // const Δλ = toRadians(to[1] - from[1]);
 
-    const a = Math.sin(Δφ / 2) ** 2 +
-              Math.cos(φ1) * Math.cos(φ2) *
-              Math.sin(Δλ / 2) ** 2;
+    // const a = Math.sin(Δφ / 2) ** 2 +
+    //           Math.cos(φ1) * Math.cos(φ2) *
+    //           Math.sin(Δλ / 2) ** 2;
 
-    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    // const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 
-    await new Promise(res => setTimeout(res, 40));
-    return R * c;
+    // await new Promise(res => setTimeout(res, 40));
+    // return R * c;
 }
 
 export function mergePathLegs(path: string[]) {
@@ -175,15 +175,15 @@ export function buildNodeLookup(routePack: RoutePack): Record<string, [number, n
 }
 
 async function getOSRMWalkingPath(from: [number, number], to: [number, number]): Promise<[number, number][]> {
-    // const url = `http://router.project-osrm.org/route/v1/foot/${from[1]},${from[0]};${to[1]},${to[0]}?overview=full&geometries=geojson`;
-    // const res = await fetch(url);
-    // const data: any = await res.json();
+    const url = `http://${process.env.EC2_OSRM_PRIVATE_IP}:5000/route/v1/foot/${from[1]},${from[0]};${to[1]},${to[0]}?overview=full&geometries=geojson`;
+    const res = await fetch(url);
+    const data: any = await res.json();
 
-    // if (data?.routes?.[0]?.geometry?.coordinates) {
-    //     return data.routes[0].geometry.coordinates.map(([lng, lat]: [number, number]) => [lat, lng]);
-    // }
+    if (data?.routes?.[0]?.geometry?.coordinates) {
+        return data.routes[0].geometry.coordinates.map(([lng, lat]: [number, number]) => [lat, lng]);
+    }
 
-    await new Promise(res => setTimeout(res, 40));
+    // await new Promise(res => setTimeout(res, 40));
 
     return [from, to]; // fallback to straight line
 }

--- a/infrastructure/komyut-cdk/cdk.context.json
+++ b/infrastructure/komyut-cdk/cdk.context.json
@@ -1,5 +1,37 @@
 {
   "acknowledged-issue-numbers": [
     34892
-  ]
+  ],
+  "vpc-provider:account=286466331800:filter.isDefault=true:region=ap-southeast-2:returnAsymmetricSubnets=true": {
+    "vpcId": "vpc-0d0f791af3ef03aba",
+    "vpcCidrBlock": "172.31.0.0/16",
+    "ownerAccountId": "286466331800",
+    "availabilityZones": [],
+    "subnetGroups": [
+      {
+        "name": "Public",
+        "type": "Public",
+        "subnets": [
+          {
+            "subnetId": "subnet-0aaf61ae969488d84",
+            "cidr": "172.31.32.0/20",
+            "availabilityZone": "ap-southeast-2a",
+            "routeTableId": "rtb-03699392557914603"
+          },
+          {
+            "subnetId": "subnet-07801b6e489683b61",
+            "cidr": "172.31.0.0/20",
+            "availabilityZone": "ap-southeast-2b",
+            "routeTableId": "rtb-03699392557914603"
+          },
+          {
+            "subnetId": "subnet-0cc0a2a7b0171cab7",
+            "cidr": "172.31.16.0/20",
+            "availabilityZone": "ap-southeast-2c",
+            "routeTableId": "rtb-03699392557914603"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/infrastructure/komyut-cdk/cdk.context.json
+++ b/infrastructure/komyut-cdk/cdk.context.json
@@ -33,5 +33,10 @@
         ]
       }
     ]
-  }
+  },
+  "availability-zones:account=286466331800:region=ap-southeast-2": [
+    "ap-southeast-2a",
+    "ap-southeast-2b",
+    "ap-southeast-2c"
+  ]
 }

--- a/infrastructure/komyut-cdk/helpers/ec2.sh
+++ b/infrastructure/komyut-cdk/helpers/ec2.sh
@@ -13,8 +13,14 @@ sudo yum install -y docker
 sudo systemctl start docker
 sudo usermod -a -G docker ec2-user
 
-echo "Setting up 10GB swap file..."
-sudo /bin/dd if=/dev/zero of=/var/swapfile bs=1M count=10240 status=progress
+echo "Waiting for /var to be ready..."
+while [ ! -d /var ]; do
+  echo "/var not ready, sleeping..."
+  sleep 2
+done
+
+echo "Setting up 20GB swap file..."
+sudo /bin/dd if=/dev/zero of=/var/swapfile bs=1M count=20480 status=progress
 sudo /sbin/mkswap /var/swapfile
 sudo chmod 600 /var/swapfile
 sudo /sbin/swapon /var/swapfile
@@ -36,7 +42,7 @@ echo "Extracting OSRM data..."
 tar -xvzf /home/ec2-user/osrm-data.tar.gz -C /home/ec2-user/data
 
 echo "Starting OSRM in Docker..."
-docker run -d -p 5000:5000 -v /home/ec2-user/data:/data osrm/osrm-backend osrm-routed --algorithm mld /data/philippines-latest.osrm > /home/ec2-user/osrm.log 2>&1
+docker run -t -i -p 5000:5000 -v /home/ec2-user/data:/data osrm/osrm-backend osrm-routed --algorithm mld /data/philippines-latest.osrm > /home/ec2-user/osrm.log 2>&1
 
 sleep 5
 echo "Appending Docker container logs to osrm.log..."

--- a/infrastructure/komyut-cdk/helpers/ec2.sh
+++ b/infrastructure/komyut-cdk/helpers/ec2.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+exec > >(tee -a /home/ec2-user/init.log | logger -t user-data -s) 2>&1
+set -x  # Print each command before executing
+
+echo "===== STARTING EC2 INIT SCRIPT ====="
+
+echo "Updating packages..."
+sudo yum update -y
+
+echo "Installing Docker..."
+sudo yum install -y docker
+sudo systemctl start docker
+sudo usermod -a -G docker ec2-user
+
+echo "Setting up 10GB swap file..."
+sudo /bin/dd if=/dev/zero of=/var/swapfile bs=1M count=10240 status=progress
+sudo /sbin/mkswap /var/swapfile
+sudo chmod 600 /var/swapfile
+sudo /sbin/swapon /var/swapfile
+echo "Swap setup complete"
+
+echo "Creating data directory..."
+mkdir -p /home/ec2-user/data
+
+echo "Waiting for osrm-data.tar.gz in S3..."
+while ! aws s3 ls s3://komyut-permanent-${ROUTEPACK_BUCKET_SUFFIX}/osrm-data.tar.gz; do
+  echo "File not yet available... waiting 30s"
+  sleep 30
+done
+
+echo "File found! Downloading..."
+aws s3 cp s3://komyut-permanent-${ROUTEPACK_BUCKET_SUFFIX}/osrm-data.tar.gz /home/ec2-user/osrm-data.tar.gz
+
+echo "Extracting OSRM data..."
+tar -xvzf /home/ec2-user/osrm-data.tar.gz -C /home/ec2-user/data
+
+echo "Starting OSRM in Docker..."
+docker run -d -p 5000:5000 -v /home/ec2-user/data:/data osrm/osrm-backend osrm-routed --algorithm mld /data/philippines-latest.osrm > /home/ec2-user/osrm.log 2>&1
+
+sleep 5
+echo "Appending Docker container logs to osrm.log..."
+docker logs $(docker ps -q --filter ancestor=osrm/osrm-backend) >> /home/ec2-user/osrm.log
+
+echo "===== EC2 INIT SCRIPT COMPLETE ====="

--- a/infrastructure/komyut-cdk/lib/komyut-cdk-stack.ts
+++ b/infrastructure/komyut-cdk/lib/komyut-cdk-stack.ts
@@ -7,8 +7,13 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
 
 import * as path from 'path';
+import * as fs from 'fs';
+
+import { CONSTS } from "@shared/consts";
 
 export class KomyutCdkStack extends cdk.Stack {
 	constructor(scope: Construct, id: string, props?: cdk.StackProps) {
@@ -18,7 +23,7 @@ export class KomyutCdkStack extends cdk.Stack {
 
 		// 💿 DYNAMODB TABLES
 
-		// ⚡ EC2 INSTANCES + VPC + SECURITY GROUPS
+		//#region ⚡ EC2 INSTANCES + VPC + SECURITY GROUPS		
 		// VPC
 		const vpc = new ec2.Vpc(this, 'KomyutVPC', {
 			maxAzs: 2,
@@ -50,9 +55,78 @@ export class KomyutCdkStack extends cdk.Stack {
 		sgEC2.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(5000), 'Allow remote to access OSRM');
 		sgEC2.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(22), 'shh(insecure)');
 
-		// [[ EC2 HAS TO BE SET UP MANUALLY! ]]
+		// EC2
+		const ec2Role = new iam.Role(this, 'Ec2Role', { assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'), });
+		const ec2Instance = new ec2.Instance(this, 'KomyutOSRM-EC2', {
+			instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO),
+			machineImage: ec2.MachineImage.latestAmazonLinux2023(),
+			blockDevices: [{
+				deviceName: '/dev/xvda',
+				volume: ec2.BlockDeviceVolume.ebs(30),
+			}],
 
-		// ⭐ LAMBDA FUNCTIONS (use lambda-nodejs NodejsFunction() instead to avoid building to .js)
+			vpc,
+			vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+			securityGroup: sgEC2,
+
+			keyName: 'osrm-keypair',
+			role: ec2Role
+		});
+		new ssm.StringParameter(this, 'KomyutEc2PrivateIP', { parameterName: '/komyut/ec2/private-ip', stringValue: ec2Instance.instancePrivateIp });
+		ec2Instance.role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'));		
+		ec2Instance.addUserData(
+			fs.readFileSync(path.join(__dirname, '../helpers/ec2.sh'), 'utf-8').replace(/\${ROUTEPACK_BUCKET_SUFFIX}/g, process.env.ROUTEPACK_BUCKET_SUFFIX!)
+		);
+		// ec2Instance.userData.addCommands(
+		// 	//Redirect all output to both a log file and the system logger
+		// 	`exec > >(tee -a /home/ec2-user/init.log | logger -t user-data -s) 2>&1`,
+		// 	`set -x  # Print each command before executing`,
+
+		// 	`echo "===== STARTING EC2 INIT SCRIPT ====="`,
+
+		// 	`echo "Updating packages..."`,
+		// 	`sudo yum update -y`,
+
+		// 	`echo "Installing Docker..."`,
+		// 	`sudo yum install -y docker`,
+		// 	`sudo systemctl start docker`,
+		// 	`sudo usermod -a -G docker ec2-user`,
+
+		// 	`echo "Setting up 10GB swap file..."`,
+		// 	`sudo /bin/dd if=/dev/zero of=/var/swapfile bs=1M count=10240 status=progress`,
+		// 	`sudo /sbin/mkswap /var/swapfile`,
+		// 	`sudo chmod 600 /var/swapfile`,
+		// 	`sudo /sbin/swapon /var/swapfile`,
+		// 	`echo "Swap setup complete"`,
+
+		// 	`echo "Creating data directory..."`,
+		// 	`mkdir -p /home/ec2-user/data`,
+
+		// 	`echo "Waiting for osrm-data.tar.gz in S3..."`,
+		// 	`while ! aws s3 ls s3://komyut-permanent-${process.env.ROUTEPACK_BUCKET_SUFFIX}/osrm-data.tar.gz; do`,
+		// 	`echo "File not yet available... waiting 30s"`,
+		// 	`sleep 30`,
+		// 	`done`,
+
+		// 	`echo "File found! Downloading..."`,
+		// 	`aws s3 cp s3://komyut-permanent-${process.env.ROUTEPACK_BUCKET_SUFFIX}/osrm-data.tar.gz /home/ec2-user/osrm-data.tar.gz`,
+
+		// 	`echo "Extracting OSRM data..."`,
+		// 	`tar -xvzf /home/ec2-user/osrm-data.tar.gz -C /home/ec2-user/data`,
+
+		// 	`echo "Starting OSRM in Docker..."`,
+		// 	`docker run -d -p 5000:5000 -v /home/ec2-user/data:/data osrm/osrm-backend osrm-routed --algorithm mld /data/philippines-latest.osrm > /home/ec2-user/osrm.log 2>&1`,
+
+		// 	`# Optional: wait a few seconds then append container logs to osrm.log`,
+		// 	`sleep 5`,
+		// 	`echo "Appending Docker container logs to osrm.log..."`,
+		// 	`docker logs $(docker ps -q --filter ancestor=osrm/osrm-backend) >> /home/ec2-user/osrm.log`,
+
+		// 	`echo "===== EC2 INIT SCRIPT COMPLETE ====="`
+		// );		
+		//#endregion
+
+		//#region ⭐ LAMBDA FUNCTIONS (use lambda-nodejs NodejsFunction() instead to avoid building to .js)
 		// ANTHONY'S WORK
 		const fnHelloWorld = new lambdaNJS.NodejsFunction(this, 'HelloWorldFunction', {
 			entry: path.join(__dirname, '../lambda/helloworld/helloworld.ts'),
@@ -66,7 +140,6 @@ export class KomyutCdkStack extends cdk.Stack {
 			memorySize: 3008, // Adjust memory size as needed (Higher Memory also = faster cpu), 3008 is the limit for Lambda
 			environment: {
 				ROUTEPACK_BUCKET_SUFFIX: process.env.ROUTEPACK_BUCKET_SUFFIX!,
-				EC2_OSRM_PRIVATE_IP: process.env.EC2_OSRM_PRIVATE_IP!,
 			},			
 
 			vpc: vpc,
@@ -75,6 +148,10 @@ export class KomyutCdkStack extends cdk.Stack {
 			},
 			securityGroups: [sgLambda],
 		});		
+		fnCalcPlan.addToRolePolicy(new iam.PolicyStatement({
+			actions: ['ssm:GetParameter'],
+			resources: ['*']
+		}))
 
 		// KARLO'S WORK
 		const fnConfirmSignup = new lambdaNJS.NodejsFunction(this, 'ConfirmSignupFunction', {
@@ -91,18 +168,25 @@ export class KomyutCdkStack extends cdk.Stack {
 			entry: path.join(__dirname, '../lambda/signup/signup.ts'),
 			runtime: lambda.Runtime.NODEJS_20_X,
 		});
+		//#endregion
 
-		// 🪣 S3 BUCKETS
+		//#region 🪣 S3 BUCKETS
 		const routePackBucket = new s3.Bucket(this, 'RoutePackBucket', {
 			bucketName: `komyut-routepack-bucket-${process.env.ROUTEPACK_BUCKET_SUFFIX}`, 
 			removalPolicy: cdk.RemovalPolicy.DESTROY,
 			autoDeleteObjects: true,
 			publicReadAccess: false,						
 		});
-		// routePackBucket.grantRead(fnTestLoadRoutePack);
+		const permanentBucket = new s3.Bucket(this, 'PermanentBucket', {
+			bucketName: `komyut-permanent-${process.env.ROUTEPACK_BUCKET_SUFFIX}`, 
+			removalPolicy: cdk.RemovalPolicy.RETAIN,			
+			publicReadAccess: false,						
+		});	
 		routePackBucket.grantRead(fnCalcPlan);
+		permanentBucket.grantRead(ec2Role);
+		//#endregion
 
-		// ☁️ CLOUDFRONT DISTRIBUTION
+		//#region ☁️ CLOUDFRONT DISTRIBUTION
 		const routePackDistribution = new cloudfront.Distribution(this, 'RoutePackDistribution', {
 		defaultBehavior: {
 			origin: new origins.S3Origin(routePackBucket),
@@ -112,9 +196,10 @@ export class KomyutCdkStack extends cdk.Stack {
 		},
 		defaultRootObject: 'routepack-bundle/routepack.json',
 		priceClass: cloudfront.PriceClass.PRICE_CLASS_200 // Choose 200 or 300 as they cover the regions we need
-		});				
+		});		
+		//#endregion		
 
-		// 🚦 APIGATEWAY DEFINITION
+		//#region 🚦 APIGATEWAY DEFINITION
 		const api = new apigw.RestApi(this, 'KomyutRestApi', {
 			defaultMethodOptions: {
     			authorizationType: apigw.AuthorizationType.NONE // Disable auth
@@ -130,7 +215,7 @@ export class KomyutCdkStack extends cdk.Stack {
 				'X-Amz-Security-Token'
 				],
 			},
-		});
+		});		
 
 		api.root.addResource('hello-world')
 			.addMethod('GET', new apigw.LambdaIntegration(fnHelloWorld));
@@ -141,5 +226,6 @@ export class KomyutCdkStack extends cdk.Stack {
 		.addMethod('POST', new apigw.LambdaIntegration(fnCalcPlan, {
 			proxy: true, // Added to allow the Lambda func to handle the request body directly
 		}));
+		//#endregion
 	}
 }

--- a/shared/consts.ts
+++ b/shared/consts.ts
@@ -1,0 +1,7 @@
+export const CONSTS = {
+    aws: {
+        ssmParams: {
+            OSRM_EC2_PRIVATE_IP: '/komyut/ec2/private-ip'
+        }
+    }
+}


### PR DESCRIPTION
**The following changes were made**
- Make relevant `VPCs`, `SecurityGroups`, and `EC2` instances.
- Redo the 'dummified' the OSRM API calls to call OSRM from our new EC2 instance
- Added ec2 automation to external `ec2.sh` script

**Other changes**
- Added new bucket for OSRM `komyut-permanent`
- Dynamic private IP resolution through SSM

**THE FOLLOWING ISSUES EXISTS IN THIS PR AND ARE TO BE RESOLVED:**
- [ ] EC2 automation fails to create swapfile properly

