### PR TITLE
fix (backend): calcplan lambda bucket not found fix

### DIFF
--- a/infrastructure/komyut-cdk/lambda/calcplan/calcplan.ts
+++ b/infrastructure/komyut-cdk/lambda/calcplan/calcplan.ts
@@ -8,6 +8,7 @@ import { calculateFare } from "infrastructure/komyut-cdk/calculation/farecalc";
 let cachedRoutePack: RoutePack | null = null;
 
 const CLOUDFRONT_DOMAIN = process.env.CLOUDFRONT_DOMAIN; 
+const ROUTEPACK_BUCKET_NAME = process.env.ROUTEPACK_BUCKET_NAME!;
 
 export const handler: APIGatewayProxyHandler = async (event) => {
     try {
@@ -21,7 +22,7 @@ export const handler: APIGatewayProxyHandler = async (event) => {
             // cachedRoutePack = await loadRoutePackFromS3Parallel('komyut-routepack-bucket', 'routepack');
             const time1 = performance.now();
             console.log(`start function loadRoutePackBundle`);
-            cachedRoutePack = await loadRoutePackBundle(`komyut-routepack-bucket-${process.env.ROUTEPACK_BUCKET_SUFFIX}`, 'routepack-bundle');
+            cachedRoutePack = await loadRoutePackBundle(ROUTEPACK_BUCKET_NAME, 'routepack-bundle');
             console.log(`loadRoutePackBundle TOOK ${(performance.now() - time1)}ms`);
             
             if (!cachedRoutePack) {


### PR DESCRIPTION
**The issue to be fixed was:**
- The `bucketName` naming convention to `routePackBucket` was not communicated, as a result `calcplan.ts` lambda was still searching for the bucket assuming the old naming convention

**The following changes were made:**
- Rearrange cdk structure
- Provide `routePackBucket.bucketName` to `calcplan` lambda through `process.env.ROUTEPACK_BUCKET_NAME` env variable